### PR TITLE
Update clang to always force 64-bit

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -80,8 +80,8 @@ cat <<zz
     fi
 
     export ZOPEN_CPPFLAGS="-DNSIG=42 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE -D_OPEN_SYS_FILE_EXT=1 -D_AE_BIMODAL=1 -D_ENHANCED_ASCII_EXT=0xFFFFFFFF"
-    export ZOPEN_CFLAGS="-fzos-le-char-mode=ascii -std=gnu11 -mnocsect -fno-short-enums -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -mzos-target=zosv2r4"
-    export ZOPEN_CXXFLAGS="-fzos-le-char-mode=ascii -mnocsect -fno-short-enums -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -mzos-target=zosv2r4"
+    export ZOPEN_CFLAGS="-fzos-le-char-mode=ascii -std=gnu11 -mnocsect -fno-short-enums -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -m64 -mzos-target=zosv2r4"
+    export ZOPEN_CXXFLAGS="-fzos-le-char-mode=ascii -mnocsect -fno-short-enums -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -m64 -mzos-target=zosv2r4"
     export ZOPEN_LDFLAGS="-Wl,-bedit=no"
     export ZOPEN_COMP="CLANG"
 


### PR DESCRIPTION
It is implicit in clang, but not in ibm-clang. See https://github.com/ZOSOpenTools/screenport/issues/5