### PR TITLE
Enable support for use of IBM Open XL C/C++ 1.Next for z/OS compiler

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -61,9 +61,18 @@ cat <<zz
       return 1
   fi
 
-  if ! \${CLANG_PATH} --version 2>&1 | grep -q "s390x-ibm-zos"; then
+  if ! \${CLANG_PATH} --version >/dev/null 2>&1; then
+    if ! STEPLIB="\$ZOPEN_OLD_STEPLIB" \${CLANG_PATH} --version >/dev/null 2>&1; then
+      echo "The clang executable is not a functional zos clang compiler. Please download and install from https://epwt-www.mybluemix.net/software/support/trial/cst/programwebsite.wss?siteId=1803." >&2
+      return 1
+    fi
+    # We need to set STEPLIB
+    export STEPLIB="\$ZOPEN_OLD_STEPLIB"
+  fi
+
+  if ! \${CLANG_PATH} --version 2>&1 | grep -q "s390x\?-ibm-zos"; then
     echo "The clang executable is not a zos clang compiler. Please download and install from https://epwt-www.mybluemix.net/software/support/trial/cst/programwebsite.wss?siteId=1803." >&2 
-    return 1;
+    return 1
   fi
 
   if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then


### PR DESCRIPTION
This compiler requires a STEPLIB to be set. The triple also does not have an x, so changed the check to make it option: s390x\?-ibm-zos.

Dependent PR: https://github.com/ZOSOpenTools/meta/pull/659